### PR TITLE
fix/edi-portal-search-box-reliability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MBU_Udskrivning_0-21aar"
-version = "1.0.11"
+version = "1.0.12"
 authors = [
   { name="MBU", email="rpa@mbu.aarhus.dk" },
 ]

--- a/robot_framework/subprocesses/process/edi/edi_portal_functions.py
+++ b/robot_framework/subprocesses/process/edi/edi_portal_functions.py
@@ -113,7 +113,11 @@ def edi_portal_check_contractor_id(
             contractor_id = extern_clinic_data[0]["contractorId"]
             clinic_phone_number = extern_clinic_data[0]["phoneNumber"]
 
-        edi_portal_click_next_button(sleep_time=5)
+        edi_portal_click_next_button(sleep_time=3)
+
+        root_web_area = self.wait_for_control(
+            auto.DocumentControl, {"AutomationId": "RootWebArea"}, search_depth=20
+        )
 
         class_options = [
             "form-control filter_search",
@@ -123,10 +127,10 @@ def edi_portal_check_contractor_id(
         for class_name in class_options:
             try:
                 search_box = wait_for_control(
-                    auto.EditControl,
+                    root_web_area.EditControl,
                     {"ClassName": class_name},
                     search_depth=22,
-                    timeout=1,
+                    timeout=2,
                 )
             except TimeoutError:
                 continue


### PR DESCRIPTION
## Changes
- Modified `edi_portal_check_contractor_id()` to first locate `root_web_area` 
- Search for EditControl within the web area context for better reliability
