### PR TITLE
fix: object has no attribute id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MBU_Udskrivning_0-21aar"
-version = "1.0.21"
+version = "1.0.22"
 authors = [
   { name="MBU", email="rpa@mbu.aarhus.dk" },
 ]


### PR DESCRIPTION
## Summary
Removed the print statement that prints the current queue element's id.

## Changes
Prevents "object has no attribute 'id'" error when there are no more elements in the queue.

## Reason
The print statement was not removed before the push.