### PR TITLE
fix: object has no attribute id

### DIFF
--- a/robot_framework/queue_framework.py
+++ b/robot_framework/queue_framework.py
@@ -35,7 +35,6 @@ def main():
                 queue_element = orchestrator_connection.get_next_queue_element(
                     config.QUEUE_NAME
                 )
-                print(f"queue_element.id: {queue_element.id}")
 
                 if not queue_element:
                     orchestrator_connection.log_info("Queue empty.")


### PR DESCRIPTION
## Summary
Removed the print statement that prints the current queue element's id.

## Changes
Prevents "object has no attribute 'id'" error when there are no more elements in the queue.

## Reason
The print statement was not removed before the push.